### PR TITLE
added support for 'servers' configuration on OpenAPI v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode
+demo/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
added support for 'servers' configuration on OpenAPI v3 based on APPLICATION_ROOT.

This is for applications wrapped in DispatcherMiddleware.